### PR TITLE
Add leptonic zed builder

### DIFF
--- a/analyzers/LeptonicZedBuilder.py
+++ b/analyzers/LeptonicZedBuilder.py
@@ -1,0 +1,68 @@
+from heppy.framework.analyzer import Analyzer
+from heppy.particles.tlv.resonance import Resonance2 as Resonance
+
+import pprint 
+import itertools
+
+class LeptonicZedBuilder(Analyzer):
+    '''Builds a list of Z resonances from an input lepton collection. 
+       Elements in this list consist in pairs of leptons. A given lepton can appear
+       only in one pair of the list.
+
+    Example:
+
+    from heppy.analyzers.LeptonicZedBuilder import LeptonicZedBuilder
+    zeds = cfg.Analyzer(
+      LeptonicZedBuilder,
+      output = 'zeds',
+      leptons = 'leptons',
+    )
+
+    * output : resulting Z resonances are stored in this collection, 
+    sorted according to their distance to the nominal Z mass. The first 
+    resonance in this collection is thus the best one. 
+    
+    Additionally, a collection zeds_legs (in this case) is created to contain the 
+    legs of the best resonance. 
+
+    * leptons : collection of leptons that will be combined into resonances.
+
+    '''
+
+    def matches(self, zed, zeds) :
+        for z in zeds:    
+            if ( zed.leg1() is z.leg1() or 
+                 zed.leg1() is z.leg2() or 
+                 zed.leg2() is z.leg1() or 
+                 zed.leg2() is z.leg2() ) : 
+                return True
+		
+    def isLeptonic(self, zed) :
+        if ( zed.leg1().pdgid() == -zed.leg2().pdgid() ) :
+            return True
+
+    def process(self, event):
+        legs = getattr(event, self.cfg_ana.leptons)
+
+        uncleaned_zeds = []
+
+        # first form all possible combinations, regardless of flavor or charge
+        for leg1, leg2 in itertools.combinations(legs,2):
+            uncleaned_zeds.append( Resonance(leg1, leg2, 23) )
+
+        # check that leptons occur only in one pair and that they are same flavor, opp charge. 
+        zeds = []
+        for z in uncleaned_zeds:
+           if not self.matches(z, zeds) : zeds.append(z) 
+        
+        # sorting according to distance to nominal mass
+        nominal_mass = 91.19
+        zeds.sort(key=lambda x: abs(x.m()-nominal_mass))
+        setattr(event, self.cfg_ana.output, zeds)
+        
+        # getting legs of best resonance
+        legs = []
+        if len(zeds):
+            legs = zeds[0].legs
+        setattr(event, '_'.join([self.cfg_ana.output, 'legs']), legs)
+

--- a/analyzers/LeptonicZedBuilder.py
+++ b/analyzers/LeptonicZedBuilder.py
@@ -11,7 +11,7 @@ class LeptonicZedBuilder(Analyzer):
 
     Example:
 
-    from heppy.analyzers.LeptonicZedBuilder import LeptonicZedBuilder
+    from heppy.FCChhAnalyses.analyzers.LeptonicZedBuilder import LeptonicZedBuilder
     zeds = cfg.Analyzer(
       LeptonicZedBuilder,
       output = 'zeds',

--- a/h4l/analysis.py
+++ b/h4l/analysis.py
@@ -273,7 +273,7 @@ selected_bs = cfg.Analyzer(
 )
 
 # create Z boson candidates with leptons
-from heppy.analyzers.LeptonicZedBuilder import LeptonicZedBuilder
+from heppy.FCChhAnalyses.analyzers.LeptonicZedBuilder import LeptonicZedBuilder
 zeds = cfg.Analyzer(
       LeptonicZedBuilder,
       output = 'zeds',

--- a/hza/analysis.py
+++ b/hza/analysis.py
@@ -205,7 +205,7 @@ selected_leptons = cfg.Analyzer(
 )
 
 # create Z boson candidates with leptons
-from heppy.analyzers.LeptonicZedBuilder import LeptonicZedBuilder
+from heppy.FCChhAnalyses.analyzers.LeptonicZedBuilder import LeptonicZedBuilder
 zeds = cfg.Analyzer(
       LeptonicZedBuilder,
       output = 'zeds',

--- a/ttV_test/analysis.py
+++ b/ttV_test/analysis.py
@@ -154,7 +154,7 @@ selection = cfg.Analyzer(
 
 
 # create Z boson candidates with leptons
-from heppy.analyzers.LeptonicZedBuilder import LeptonicZedBuilder
+from heppy.FCChhAnalyses.analyzers.LeptonicZedBuilder import LeptonicZedBuilder
 zeds = cfg.Analyzer(
       LeptonicZedBuilder,
       output = 'zeds',

--- a/tth_4l/analysis.py
+++ b/tth_4l/analysis.py
@@ -140,7 +140,7 @@ selected_bs = cfg.Analyzer(
 )
 
 # create Z boson candidates with leptons
-from heppy.analyzers.LeptonicZedBuilder import LeptonicZedBuilder
+from heppy.FCChhAnalyses.analyzers.LeptonicZedBuilder import LeptonicZedBuilder
 zeds = cfg.Analyzer(
       LeptonicZedBuilder,
       output = 'zeds',


### PR DESCRIPTION
The `LeptonicZedBuilder` will be removed from heppy (https://github.com/HEP-FCC/heppy/issues/73) It can be substituted with more general analyzers, but for the short term it is best to add it here.